### PR TITLE
Constrain peer dep @playwright/test to v1 or compatible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3810,7 +3810,7 @@
       },
       "peerDependencies": {
         "@bufbuild/connect": "^0.12.0",
-        "@playwright/test": ">=1.0.0"
+        "@playwright/test": "^1.0.0"
       }
     },
     "packages/connect-playwright-example": {

--- a/packages/connect-playwright/package.json
+++ b/packages/connect-playwright/package.json
@@ -36,7 +36,7 @@
   },
   "peerDependencies": {
     "@bufbuild/connect": "^0.12.0",
-    "@playwright/test": ">=1.0.0"
+    "@playwright/test": "^1.0.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.37.0"


### PR DESCRIPTION
`>=1.0.0` would also match v2 of @playwright/test, and it is very likely to include breaking changes we would also be incompatible with.