### PR TITLE
Release 0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4070,7 +4070,7 @@
         "@bufbuild/protoc-gen-es": "^1.3.0",
         "@connectrpc/connect": "^0.13.1",
         "@connectrpc/connect-web": "^0.13.1",
-        "@connectrpc/protoc-gen-connect-es": "^0.13.0",
+        "@connectrpc/protoc-gen-connect-es": "^0.13.1",
         "@types/react": "^18.2.18",
         "@types/react-dom": "^18.2.6",
         "esbuild": "^0.19.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4045,7 +4045,7 @@
     },
     "packages/connect-playwright": {
       "name": "@connectrpc/connect-playwright",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@playwright/test": "^1.37.0"
@@ -4059,7 +4059,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@connectrpc/connect-playwright": "0.2.0",
+        "@connectrpc/connect-playwright": "0.3.0",
         "@playwright/test": "^1.37.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/connect-playwright-example/package.json
+++ b/packages/connect-playwright-example/package.json
@@ -26,7 +26,7 @@
     "typescript": "^5.1.3"
   },
   "dependencies": {
-    "@connectrpc/connect-playwright": "0.2.0",
+    "@connectrpc/connect-playwright": "0.3.0",
     "@playwright/test": "^1.37.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/packages/connect-playwright-example/package.json
+++ b/packages/connect-playwright-example/package.json
@@ -17,7 +17,7 @@
     "@connectrpc/connect": "^0.13.1",
     "@connectrpc/connect-web": "^0.13.1",
     "@bufbuild/protobuf": "^1.2.1",
-    "@connectrpc/protoc-gen-connect-es": "^0.13.0",
+    "@connectrpc/protoc-gen-connect-es": "^0.13.1",
     "@bufbuild/protoc-gen-es": "^1.3.0",
     "@types/react": "^18.2.18",
     "@types/react-dom": "^18.2.6",

--- a/packages/connect-playwright/package.json
+++ b/packages/connect-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-playwright",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "description": "e2e utilities for use with Playwright and Connect",
   "type": "module",


### PR DESCRIPTION
## What's Changed

To keep Connect well-maintained and responsive to its users' needs over the long term, we're preparing to donate it to a foundation. (More details on that soon!) To cleanly separate Connect from Buf's other code, we're moving development to the [connectrpc](https://github.com/connectrpc) GitHub organization and to the [connectrpc](https://www.npmjs.com/org/connectrpc) organization on npmjs.com.

This is the first release of `@connectrpc/connect-playwright` to use `@connectrpc/connect`. 

If you have been using connect-playwright before, the best way to install the new version is:
- Remove connect-playwright with `npm remove @connectrpc/connect-playwright`.
- Update your dependencies to the latest version of the `@bufbuild/connect` packages.
- Run `npx @connectrpc/connect-migrate` to switch to the `@connectrpc/connect` packages.
- Re-install connect-playwright with `npm install @connectrpc/connect-playwright`.

If you have never used connect-playwright, give it a try with `npm install @connectrpc/connect-playwright`.