### PR TITLE
Add explicit exports for Node

### DIFF
--- a/packages/connect-playwright/package.json
+++ b/packages/connect-playwright/package.json
@@ -25,9 +25,13 @@
   "main": "./dist/cjs/index.js",
   "exports": {
     ".": {
+      "node": {
+        "import": "./dist/proxy/index.js",
+        "require": "./dist/cjs/index.js"
+      },
       "module": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js",
-      "import": "./dist/proxy/index.js"
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js"
     }
   },
   "peerDependencies": {


### PR DESCRIPTION
 This adds explicit exports for node into the package.json for all published packages in Connect-ES. In addition, it modifies the path for the top-level import statement to use ESM instead of the proxy.

For additional context, see https://github.com/connectrpc/connect-es/pull/921

