### PR TITLE
Handle mocking gRPC-web

### DIFF
--- a/packages/connect-playwright-example/src/App.tsx
+++ b/packages/connect-playwright-example/src/App.tsx
@@ -26,6 +26,9 @@ interface ChatMessage {
 }
 
 // Read the transport and format parameters from the URL
+// Note that users do not need to worry about this since this is just for
+// testing purposes so that we can easily verify various transports and
+// serialization formats.
 const params = new URLSearchParams(window.location.search);
 const transportParam = params.get("transport");
 const format = params.get("format");

--- a/packages/connect-playwright-example/src/App.tsx
+++ b/packages/connect-playwright-example/src/App.tsx
@@ -35,11 +35,11 @@ let transportFn;
 if (transportParam === "grpcweb") {
   transportFn = createGrpcWebTransport;
   // gRPC-web uses the binary format by default
-  useBinaryFormat = format ? format === "binary" : true;
+  useBinaryFormat = format !== null ? format === "binary" : true;
 } else {
   transportFn = createConnectTransport;
   // Connect uses the JSON format by default
-  useBinaryFormat = format ? format === "binary" : false;
+  useBinaryFormat = format !== null ? format === "binary" : false;
 }
 
 const elizaClient = createPromiseClient(

--- a/packages/connect-playwright-example/src/App.tsx
+++ b/packages/connect-playwright-example/src/App.tsx
@@ -35,7 +35,7 @@ let transportFn;
 if (transportParam === "grpcweb") {
   transportFn = createGrpcWebTransport;
   // gRPC-web uses the binary format by default
-  useBinaryFormat = format !== null ? format === "binary" : true;
+  useBinaryFormat = format === "binary";
 } else {
   transportFn = createConnectTransport;
   // Connect uses the JSON format by default

--- a/packages/connect-playwright-example/tests/more.spec.ts
+++ b/packages/connect-playwright-example/tests/more.spec.ts
@@ -39,7 +39,7 @@ test.describe("more mocking", () => {
     await page.goto(project.use.baseURL ?? "");
 
     // Type some text and send
-    await statementInput.type("Hello");
+    await statementInput.fill("Hello");
     await sendButton.click();
 
     // This should NOT be the mocked response and instead should be passed through
@@ -54,7 +54,7 @@ test.describe("more mocking", () => {
       await page.goto(project.use.baseURL ?? "");
 
       // Type a name and send
-      await statementInput.type("Hello");
+      await statementInput.fill("Hello");
       await sendButton.click();
 
       // This should be empty text, because we configured the service with "mock" above,
@@ -84,7 +84,7 @@ test.describe("more mocking", () => {
       await page.goto(project.use.baseURL ?? "");
 
       // Type a name and send
-      await statementInput.type("Hello");
+      await statementInput.fill("Hello");
       await sendButton.click();
 
       // This should be the mocked response we set in our call to mock.rpc()
@@ -108,7 +108,7 @@ test.describe("more mocking", () => {
       await page.goto(project.use.baseURL ?? "");
 
       // Type a name and send
-      await statementInput.type("Hello");
+      await statementInput.fill("Hello");
       await sendButton.click();
 
       // This should be empty text, because we configured the service with "mock" above,
@@ -131,7 +131,7 @@ test.describe("more mocking", () => {
       await page.goto(project.use.baseURL ?? "");
 
       // Type a name and send
-      await statementInput.type("Hello");
+      await statementInput.fill("Hello");
       await sendButton.click();
 
       // This should be the mocked response we set in our call to mock.rpc()
@@ -151,7 +151,7 @@ test.describe("more mocking", () => {
       await page.goto(project.use.baseURL ?? "");
 
       // Type a name and send
-      await statementInput.type("Hello");
+      await statementInput.fill("Hello");
       await sendButton.click();
 
       // This should be empty text, because we configured the RPC with "mock" above,

--- a/packages/connect-playwright-example/tests/simple.spec.ts
+++ b/packages/connect-playwright-example/tests/simple.spec.ts
@@ -47,7 +47,7 @@ test.describe("mocking Eliza", () => {
     await page.goto(project.use.baseURL ?? "");
 
     // Type a name and send
-    await statementInput.type("Hello");
+    await statementInput.fill("Hello");
     await sendButton.click();
 
     // This should be the mocked response we return from say() above
@@ -60,7 +60,7 @@ test.describe("mocking Eliza", () => {
     await page.goto(project.use.baseURL ?? "");
 
     // Type a name and send
-    await statementInput.type("Hello");
+    await statementInput.fill("Hello");
     await sendButton.click();
 
     // This should be empty text, because we configured the service with "mock" above,
@@ -81,7 +81,7 @@ test.describe("mocking Eliza", () => {
     await page.goto(project.use.baseURL ?? "");
 
     // Type a name and send
-    await statementInput.type("Hello");
+    await statementInput.fill("Hello");
     await sendButton.click();
 
     // In the app, calling say() rejected with a ConnectError.
@@ -100,7 +100,7 @@ test.describe("mocking Eliza", () => {
     await page.goto(project.use.baseURL ?? "");
 
     // Type a name and send
-    await statementInput.type("Hello");
+    await statementInput.fill("Hello");
     await sendButton.click();
 
     // This should NOT be the mocked response and instead should be passed through

--- a/packages/connect-playwright-example/tests/transport.spec.ts
+++ b/packages/connect-playwright-example/tests/transport.spec.ts
@@ -44,68 +44,22 @@ test.describe("transports", () => {
     });
   });
 
-  test("treats no params as connect with JSON and correctly mocks", async ({
-    page,
-  }) => {
-    await page.goto(baseURL);
+  [
+    baseURL,
+    baseURL + "?transport=connect",
+    baseURL + "?transport=connect&format=binary",
+    baseURL + "?transport=grpcweb",
+    baseURL + "?transport=grpcweb&format=json",
+  ].forEach((url) => {
+    test(`correctly mocks with params ${url}`, async ({ page }) => {
+      await page.goto(url);
 
-    // Type a name and send
-    await statementInput.fill("Hello");
-    await sendButton.click();
+      // Type a name and send
+      await statementInput.fill("Hello");
+      await sendButton.click();
 
-    // This should be the mocked response we return from say() above
-    await expect(respText).toHaveText("Mock response");
-  });
-
-  test("correctly mocks a connect transport in JSON format", async ({
-    page,
-  }) => {
-    await page.goto(baseURL + "?transport=connect");
-
-    // Type a name and send
-    await statementInput.fill("Hello");
-    await sendButton.click();
-
-    // This should be the mocked response we return from say() above
-    await expect(respText).toHaveText("Mock response");
-  });
-
-  test("correctly mocks a connect transport in binary format", async ({
-    page,
-  }) => {
-    await page.goto(baseURL + "?transport=connect&format=binary");
-
-    // Type a name and send
-    await statementInput.fill("Hello");
-    await sendButton.click();
-
-    // This should be the mocked response we return from say() above
-    await expect(respText).toHaveText("Mock response");
-  });
-
-  test("correctly mocks a grpc web transport in binary format", async ({
-    page,
-  }) => {
-    await page.goto(baseURL + "?transport=grpcweb");
-
-    // Type a name and send
-    await statementInput.fill("Hello");
-    await sendButton.click();
-
-    // This should be the mocked response we return from say() above
-    await expect(respText).toHaveText("Mock response");
-  });
-
-  test("correctly mocks a grpc web transport in JSON format", async ({
-    page,
-  }) => {
-    await page.goto(baseURL + "?transport=grpcweb&format=json");
-
-    // Type a name and send
-    await statementInput.fill("Hello");
-    await sendButton.click();
-
-    // This should be the mocked response we return from say() above
-    await expect(respText).toHaveText("Mock response");
+      // This should be the mocked response we return from say() above
+      await expect(respText).toHaveText("Mock response");
+    });
   });
 });

--- a/packages/connect-playwright-example/tests/transport.spec.ts
+++ b/packages/connect-playwright-example/tests/transport.spec.ts
@@ -1,0 +1,111 @@
+// Copyright 2023-2024 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { expect, Locator, test } from "@playwright/test";
+
+import { ElizaService } from "../src/gen/connectrpc/eliza/v1/eliza_connect.js";
+import { createMockRouter, MockRouter } from "@connectrpc/connect-playwright";
+
+test.describe("transports", () => {
+  let respText: Locator;
+  let statementInput: Locator;
+  let sendButton: Locator;
+  let mock: MockRouter;
+  let baseURL = "";
+
+  test.beforeEach(async ({ page, context }, { project }) => {
+    respText = page.locator(".eliza-resp-container p");
+    statementInput = page.locator("#statement-input");
+    sendButton = page.locator("#send");
+
+    baseURL = project.use.baseURL ?? "";
+
+    mock = createMockRouter(context, {
+      baseUrl: "https://demo.connectrpc.com",
+    });
+
+    await mock.service(ElizaService, {
+      say() {
+        return {
+          sentence: "Mock response",
+        };
+      },
+    });
+  });
+
+  test("treats no params as connect with JSON and correctly mocks", async ({
+    page,
+  }) => {
+    await page.goto(baseURL);
+
+    // Type a name and send
+    await statementInput.fill("Hello");
+    await sendButton.click();
+
+    // This should be the mocked response we return from say() above
+    await expect(respText).toHaveText("Mock response");
+  });
+
+  test("correctly mocks a connect transport in JSON format", async ({
+    page,
+  }) => {
+    await page.goto(baseURL + "?transport=connect");
+
+    // Type a name and send
+    await statementInput.fill("Hello");
+    await sendButton.click();
+
+    // This should be the mocked response we return from say() above
+    await expect(respText).toHaveText("Mock response");
+  });
+
+  test("correctly mocks a connect transport in binary format", async ({
+    page,
+  }) => {
+    await page.goto(baseURL + "?transport=connect&format=binary");
+
+    // Type a name and send
+    await statementInput.fill("Hello");
+    await sendButton.click();
+
+    // This should be the mocked response we return from say() above
+    await expect(respText).toHaveText("Mock response");
+  });
+
+  test("correctly mocks a grpc web transport in binary format", async ({
+    page,
+  }) => {
+    await page.goto(baseURL + "?transport=grpcweb");
+
+    // Type a name and send
+    await statementInput.fill("Hello");
+    await sendButton.click();
+
+    // This should be the mocked response we return from say() above
+    await expect(respText).toHaveText("Mock response");
+  });
+
+  test("correctly mocks a grpc web transport in JSON format", async ({
+    page,
+  }) => {
+    await page.goto(baseURL + "?transport=grpcweb&format=json");
+
+    // Type a name and send
+    await statementInput.fill("Hello");
+    await sendButton.click();
+
+    // This should be the mocked response we return from say() above
+    await expect(respText).toHaveText("Mock response");
+  });
+});

--- a/packages/connect-playwright-example/tests/transport.spec.ts
+++ b/packages/connect-playwright-example/tests/transport.spec.ts
@@ -47,7 +47,9 @@ test.describe("transports", () => {
   [
     baseURL,
     baseURL + "?transport=connect",
+    baseURL + "?transport=connect&useHttpGet=true",
     baseURL + "?transport=connect&format=binary",
+    baseURL + "?transport=connect&format=binary&useHttpGet=true",
     baseURL + "?transport=grpcweb",
     baseURL + "?transport=grpcweb&format=json",
   ].forEach((url) => {

--- a/packages/connect-playwright/src/create-mock-router.ts
+++ b/packages/connect-playwright/src/create-mock-router.ts
@@ -139,8 +139,9 @@ export function createMockRouter(
           );
 
           if (associatedMethod === undefined) {
-            // prettier-ignore
-            throw new Error(`No associated method found for url ${request.url()}`);
+            throw new Error(
+              `No associated method found for url ${request.url()}`,
+            );
           }
           // Automatically pass-through all non-unary methods
           if (associatedMethod.kind !== MethodKind.Unary) {
@@ -197,6 +198,7 @@ async function universalHandlerToRouteResponse({
   } else {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     body = request.postDataBuffer();
+    // gRPC-web expects the body to be an AsyncIterable
     if (contentType.startsWith("application/grpc-web")) {
       body = createAsyncIterable([body]);
     }

--- a/packages/connect-playwright/src/create-mock-router.ts
+++ b/packages/connect-playwright/src/create-mock-router.ts
@@ -204,9 +204,7 @@ async function universalHandlerToRouteResponse({
   const abortSignal = new AbortController().signal;
 
   // Default body to an empty byte stream
-  let body: UniversalServerRequest["body"] = createAsyncIterable<Uint8Array>(
-    [],
-  );
+  let body: UniversalServerRequest["body"];
 
   if (headers["content-type"] === "application/json") {
     // If content type headers are present and set to JSON, this is a POST
@@ -218,6 +216,8 @@ async function universalHandlerToRouteResponse({
       // If postDataBuffer returns a non-null body, this is a POST
       // request with a binary body
       body = createAsyncIterable<Uint8Array>([buffer]);
+    } else {
+      body = createAsyncIterable<Uint8Array>([]);
     }
   }
 

--- a/packages/connect-playwright/src/create-mock-router.ts
+++ b/packages/connect-playwright/src/create-mock-router.ts
@@ -62,7 +62,7 @@ interface Options {
   binaryOptions?: Partial<BinaryReadOptions & BinaryWriteOptions>;
 }
 
-// Builds a regular express for matching paths by appending the suffix onto
+// Builds a regular expression for matching paths by appending the suffix onto
 // base and escaping forward slashes and periods
 function buildPathRegex(base: string, suffix: string) {
   const sanitized = base


### PR DESCRIPTION
The `GrpcWebTransport` expects all request bodies to be an `AsyncIterable`, but Playwright's APIs for accessing the request body only return JSON or a Buffer. So, when creating a mock router, the handler should look at the content type and if it's gRPC-web, convert the body to an `AsyncIterable`.

In addition, this fixes mocking GET requests via the Connect protocol.

Finally, this adds some tests to verify the mocks are correctly created for Connect and gRPC-web in both JSON and binary formats and with / without GET support for the Connect protocol.