### PR TITLE
Release 0.4.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        node-version: [18, 20]
+        node-version: [18, 20, 22]
     steps:
       - uses: actions/setup-node@v4
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -4372,7 +4372,7 @@
     },
     "packages/connect-playwright": {
       "name": "@connectrpc/connect-playwright",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.15.3",
@@ -4389,7 +4389,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@connectrpc/connect-playwright": "^0.3.2",
+        "@connectrpc/connect-playwright": "^0.4.0",
         "@playwright/test": "^1.46.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"

--- a/packages/connect-playwright-example/package.json
+++ b/packages/connect-playwright-example/package.json
@@ -26,7 +26,7 @@
     "typescript": "^5.5.4"
   },
   "dependencies": {
-    "@connectrpc/connect-playwright": "^0.3.2",
+    "@connectrpc/connect-playwright": "^0.4.0",
     "@playwright/test": "^1.46.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/packages/connect-playwright/package.json
+++ b/packages/connect-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-playwright",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "license": "Apache-2.0",
   "description": "e2e utilities for use with Playwright and Connect",
   "repository": {


### PR DESCRIPTION
## What's Changed

This release updates to protobuf-es v2, and to connect-es v2. Note that this release requires a pre-release version of connect-es.

Please continue to use v0.3.2 if you don't want to switch to v2 of protobuf-es and connect-es yet.

**Full Changelog**: https://github.com/connectrpc/connect-playwright-es/compare/v0.3.2...v0.4.0