### PR TITLE
Release 0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -286,9 +286,10 @@
       }
     },
     "node_modules/@connectrpc/connect": {
-      "version": "2.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.0.0-rc.2.tgz",
-      "integrity": "sha512-EBXUD82U1Z6eWhFu+90ZvuEUCM8K03gV7cGNSQXJ9kDV07dfuvm/LevbzMEsST43Wea6ywYzd2HBNEAPJCxu8g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.0.0.tgz",
+      "integrity": "sha512-Usm8jgaaULANJU8vVnhWssSA6nrZ4DJEAbkNtXSoZay2YD5fDyMukCxu8NEhCvFzfHvrhxhcjttvgpyhOM7xAQ==",
+      "license": "Apache-2.0",
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.2.0"
       }
@@ -298,13 +299,14 @@
       "link": true
     },
     "node_modules/@connectrpc/connect-web": {
-      "version": "2.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@connectrpc/connect-web/-/connect-web-2.0.0-rc.2.tgz",
-      "integrity": "sha512-HMIDXahQtPNcmsLVfHxjKLp4oRz2b89VOCMJpt3zNMd1fzC27Ipf7Wf+7OPmER61xc9mJVkMY0D6XUPw0vB9aQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-web/-/connect-web-2.0.0.tgz",
+      "integrity": "sha512-oeCxqHXLXlWJdmcvp9L3scgAuK+FjNSn+twyhUxc8yvDbTumnt5Io+LnBzSYxAdUdYqTw5yHfTSCJ4hj0QID0g==",
       "dev": true,
+      "license": "Apache-2.0",
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.2.0",
-        "@connectrpc/connect": "2.0.0-rc.2"
+        "@connectrpc/connect": "2.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -4822,7 +4824,7 @@
     },
     "packages/connect-playwright": {
       "name": "@connectrpc/connect-playwright",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.16.4",
@@ -4831,7 +4833,7 @@
         "@types/node": "^22.8.6"
       },
       "peerDependencies": {
-        "@connectrpc/connect": "^2.0.0-rc.1",
+        "@connectrpc/connect": "^2.0.0",
         "@playwright/test": "^1.0.0"
       }
     },
@@ -4839,7 +4841,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@connectrpc/connect-playwright": "^0.5.0",
+        "@connectrpc/connect-playwright": "^0.6.0",
         "@playwright/test": "^1.48.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
@@ -4848,8 +4850,8 @@
         "@bufbuild/buf": "^1.46.0",
         "@bufbuild/protobuf": "^2.2.1",
         "@bufbuild/protoc-gen-es": "^2.2.1",
-        "@connectrpc/connect": "^2.0.0-rc.2",
-        "@connectrpc/connect-web": "^2.0.0-rc.2",
+        "@connectrpc/connect": "^2.0.0",
+        "@connectrpc/connect-web": "^2.0.0",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "esbuild": "^0.24.0",

--- a/packages/connect-playwright-example/package.json
+++ b/packages/connect-playwright-example/package.json
@@ -17,8 +17,8 @@
     "@bufbuild/buf": "^1.46.0",
     "@bufbuild/protobuf": "^2.2.1",
     "@bufbuild/protoc-gen-es": "^2.2.1",
-    "@connectrpc/connect": "^2.0.0-rc.2",
-    "@connectrpc/connect-web": "^2.0.0-rc.2",
+    "@connectrpc/connect": "^2.0.0",
+    "@connectrpc/connect-web": "^2.0.0",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "esbuild": "^0.24.0",
@@ -26,7 +26,7 @@
     "typescript": "~5.6.3"
   },
   "dependencies": {
-    "@connectrpc/connect-playwright": "^0.5.0",
+    "@connectrpc/connect-playwright": "^0.6.0",
     "@playwright/test": "^1.48.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/packages/connect-playwright/package.json
+++ b/packages/connect-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-playwright",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "Apache-2.0",
   "description": "e2e utilities for use with Playwright and Connect",
   "repository": {
@@ -31,7 +31,7 @@
     }
   },
   "peerDependencies": {
-    "@connectrpc/connect": "^2.0.0-rc.1",
+    "@connectrpc/connect": "^2.0.0",
     "@playwright/test": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## What's Changed

This release upgrades to Connect-ES and Protobuf-ES version 2.

The upgrade of the Protobuf runtime brings support for [Editions](https://buf.build/blog/protobuf-editions-are-here) and new APIs for Protobuf messages with support for custom options. Messages are now plain TypeScript types, which greatly improves compatibility with the ecosystem. 

> [!TIP]
> If you are already using Connect, see our [migration guide](https://github.com/connectrpc/connect-es/blob/main/MIGRATING.md) to upgrade to version 2.
